### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Add focus-visible styles for keyboard navigation
+**Learning:** Found that this project lacked any `:focus-visible` styles, leading to poor keyboard navigation UX since users couldn't see where their focus was. Applying a global `*:focus-visible` using the design system's `--primary-hover` variable creates an immediate and noticeable accessibility win without adding complexity.
+**Action:** Always check for existing focus styles, particularly `:focus-visible` instead of `:focus` so that mouse users' experience is not impacted, while fully supporting keyboard navigators.

--- a/css/style.css
+++ b/css/style.css
@@ -767,3 +767,10 @@ code {
   z-index: 850;
 }
 .overlay.active { display: block; }
+
+/* ===== ACCESSIBILITY ===== */
+*:focus-visible {
+  outline: 2px solid var(--primary-hover);
+  outline-offset: 2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
💡 What: Added global `:focus-visible` styles using the existing `--primary-hover` variable for the outline.\n🎯 Why: Keyboard users had no visual feedback on interactive elements (links, buttons, form fields) because focus styles were missing from the CSS.\n📸 Before/After: Visual focus ring now properly displayed when navigating with Tab key.\n♿ Accessibility: Ensures keyboard accessibility (WCAG 2.1 SC 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [9310218708207832590](https://jules.google.com/task/9310218708207832590) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added consistent focus indicator styling across interactive elements with enhanced visual definition.

* **Documentation**
  * Added documentation entry describing updated focus styling implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rsmk27/MSME-webpage/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->