### PR TITLE
🧪 Add tests for USART2_print

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,5 @@
 test_error
 user_switch_tested.c
 test_processed.c
+test_usart2
+led_tested.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,9 @@ test:
 	sed 's/while (1)/if (1) { loop_entered = 1; longjmp(test_env, 1); } while (0)/g' ../data/user_switch.c | sed 's/int main/int original_main/g' > user_switch_tested.c
 	$(CC) $(CFLAGS) -o test_error test_error_handler.c user_switch_tested.c
 	./test_error
+	sed 's/int main(void)/int original_main(void)/g' ../data/led_on_off_print_terminal.c | sed 's/void USART2_write(char ch)/void original_USART2_write(char ch)/g' > led_tested.c
+	$(CC) $(CFLAGS) -o test_usart2 test_usart2_print.c led_tested.c
+	./test_usart2
 
 clean:
-	rm -f test_error user_switch_tested.c
+	rm -f test_error user_switch_tested.c test_usart2 led_tested.c

--- a/tests/stm32f4xx.h
+++ b/tests/stm32f4xx.h
@@ -1,0 +1,35 @@
+#ifndef STM32F4XX_H
+#define STM32F4XX_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t AHB1ENR;
+    uint32_t APB1ENR;
+} RCC_TypeDef;
+
+typedef struct {
+    uint32_t MODER;
+    uint32_t ODR;
+    uint32_t AFR[2];
+} GPIO_TypeDef;
+
+typedef struct {
+    uint32_t BRR;
+    uint32_t CR1;
+    uint32_t SR;
+    uint32_t DR;
+} USART_TypeDef;
+
+typedef struct {
+    uint32_t LOAD;
+    uint32_t VAL;
+    uint32_t CTRL;
+} SysTick_TypeDef;
+
+extern RCC_TypeDef *RCC;
+extern GPIO_TypeDef *GPIOA;
+extern USART_TypeDef *USART2;
+extern SysTick_TypeDef *SysTick;
+
+#endif

--- a/tests/test_usart2_print.c
+++ b/tests/test_usart2_print.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "stm32f4xx.h"
+
+// Define the mock structures
+RCC_TypeDef mock_RCC;
+GPIO_TypeDef mock_GPIOA;
+USART_TypeDef mock_USART2;
+SysTick_TypeDef mock_SysTick;
+
+RCC_TypeDef *RCC = &mock_RCC;
+GPIO_TypeDef *GPIOA = &mock_GPIOA;
+USART_TypeDef *USART2 = &mock_USART2;
+SysTick_TypeDef *SysTick = &mock_SysTick;
+
+// Captured buffer
+char captured_str[1024];
+int capture_idx = 0;
+
+void USART2_write(char ch) {
+    if (capture_idx < sizeof(captured_str) - 1) {
+        captured_str[capture_idx++] = ch;
+        captured_str[capture_idx] = '\0';
+    }
+}
+
+// Declare the function we want to test
+extern void USART2_print(char *str);
+
+int main() {
+    printf("Starting USART2_print test...\n");
+
+    // Clear buffer
+    capture_idx = 0;
+    captured_str[0] = '\0';
+
+    USART2_print("Hello, world!");
+
+    assert(strcmp(captured_str, "Hello, world!") == 0);
+
+    // Clear buffer again and test empty string
+    capture_idx = 0;
+    captured_str[0] = '\0';
+
+    USART2_print("");
+    assert(strcmp(captured_str, "") == 0);
+
+    // Test a long string
+    capture_idx = 0;
+    captured_str[0] = '\0';
+
+    USART2_print("1234567890\r\n");
+    assert(strcmp(captured_str, "1234567890\r\n") == 0);
+
+    printf("USART2_print test passed!\n");
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** The `USART2_print` function from `data/led_on_off_print_terminal.c` was missing tests. I added tests for it by mocking the `USART2_write` function to intercept characters and verify the output buffer.
📊 **Coverage:** The tests now cover standard strings, empty strings, and strings with special characters like carriage returns.
✨ **Result:** Test coverage for `USART2_print` is now complete, ensuring that the function behaves correctly across different inputs.

---
*PR created automatically by Jules for task [16142606550272717646](https://jules.google.com/task/16142606550272717646) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with additional build procedures and artifact management.
  * Added mock hardware register definitions for STM32F4 peripheral interfaces.
  * Expanded test suite to validate UART output functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rsmk27/MSME-webpage/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->