### PR TITLE
🔒 Fix hardcoded credentials vulnerability in documentation

### DIFF
--- a/iot.html
+++ b/iot.html
@@ -170,9 +170,10 @@ client.connect(<span class="str">"dev.rightech.io"</span>, <span class="num">188
 
       <h3>STM32 → ESP8266 via UART (AT Commands)</h3>
       <div class="code-block"><pre><span class="cm">/* Connect to Wi-Fi */</span>
+<span class="cm">/* WARNING: Do not hardcode credentials in production */</span>
 <span class="fn">HAL_UART_Transmit</span>(&amp;huart1,
-  (<span class="kw">uint8_t</span>*)<span class="str">"AT+CWJAP=\"SSID\",\"PASSWORD\"\r\n"</span>,
-  strlen(<span class="str">"AT+CWJAP=\"SSID\",\"PASSWORD\"\r\n"</span>), <span class="num">5000</span>);
+  (<span class="kw">uint8_t</span>*)<span class="str">"AT+CWJAP=\"YOUR_SSID\",\"YOUR_PASSWORD\"\r\n"</span>,
+  strlen(<span class="str">"AT+CWJAP=\"YOUR_SSID\",\"YOUR_PASSWORD\"\r\n"</span>), <span class="num">5000</span>);
 
 <span class="cm">/* Publish to MQTT topic via Rightech */</span>
 <span class="fn">HAL_UART_Transmit</span>(&amp;huart1,


### PR DESCRIPTION
🎯 What: Replaced hardcoded example password and SSID with placeholders in iot.html. Added a warning comment against hardcoding credentials.
⚠️ Risk: Hardcoding credentials in documentation might encourage users to do the same in their actual code, leading to potential security breaches.
🛡️ Solution: Updated the code snippet to use placeholders (YOUR_SSID, YOUR_PASSWORD) and included a clear warning comment.

---
*PR created automatically by Jules for task [17963302369588402545](https://jules.google.com/task/17963302369588402545) started by @Rsmk27*