### PR TITLE
⚡ [performance improvement] Replace busy-wait with WFI interrupt delay

### DIFF
--- a/data/led_on_off_print_terminal.c
+++ b/data/led_on_off_print_terminal.c
@@ -1,5 +1,17 @@
 #include "stm32f4xx.h"
 
+volatile uint32_t msTicks = 0;
+
+void SysTick_Handler(void) { msTicks++; }
+
+void SysTick_Init(void) {
+  /* Configure SysTick to generate 1ms interrupts
+   * Default clock is 16MHz HSI */
+  SysTick->LOAD = 16000 - 1;
+  SysTick->VAL = 0;
+  SysTick->CTRL = 7; /* Enable SysTick, internal clock, enable interrupt */
+}
+
 void delayMS(int n);
 void USART2_init(void);
 void USART2_write(char ch);
@@ -16,6 +28,9 @@ int main(void) {
 
   /* USART2 init */
   USART2_init();
+
+  /* SysTick init */
+  SysTick_Init();
 
   while (1) {
     GPIOA->ODR |= 0x20; // LED ON
@@ -52,20 +67,12 @@ void USART2_print(char *str) {
   }
 }
 
-/* Delay function using SysTick timer */
+/* Delay function using SysTick interrupt */
 void delayMS(int n) {
-  /* Configure SysTick to generate 1ms delay
-   * Default clock is 16MHz HSI */
-  SysTick->LOAD = 16000 - 1;
-  SysTick->VAL = 0;
-  SysTick->CTRL = 5; /* Enable SysTick, internal clock, no interrupt */
-
-  for (int i = 0; i < n; i++) {
-    /* Wait until COUNTFLAG is set */
-    while ((SysTick->CTRL & 0x10000) == 0)
-      ;
+  uint32_t startTicks = msTicks;
+  while ((msTicks - startTicks) < (uint32_t)n) {
+#ifdef __arm__
+    __asm volatile("wfi");
+#endif
   }
-
-  /* Disable SysTick */
-  SysTick->CTRL = 0;
 }


### PR DESCRIPTION
### 💡 What
Replaced the busy-wait polling loop in the `delayMS` function with an interrupt-driven delay mechanism.
* Added a global `volatile uint32_t msTicks` counter.
* Implemented the `SysTick_Handler` to increment the counter every millisecond.
* Added `SysTick_Init` to configure the 1ms interrupt correctly and called it from `main`.
* Rewrote `delayMS` to evaluate the ticks and utilize the ARM `WFI` (Wait For Interrupt) instruction (safely guarded by `#ifdef __arm__`) to place the core into sleep mode until awakened by an interrupt.

### 🎯 Why
The original delay mechanism functioned by continuously polling the SysTick `CTRL` register to check if the `COUNTFLAG` bit was set. This "busy-waiting" caused the CPU to operate at 100% active state for the duration of the delay, wasting significant amounts of power and holding the bus unnecessarily. Changing to an interrupt-based model frees the CPU to sleep when idle.

### 📊 Measured Improvement
**Rationale for Benchmark Constraints:**
Because the code targets a bare-metal STM32 microcontroller and relies heavily on hardware-specific behaviors (such as the SysTick CTRL register's COUNTFLAG hardware clearing upon read), measuring the precise performance impact computationally in our simulated x86 host test environment is impractical. Simulating the original polling loop directly on the host using mocked memory struct causes an infinite or incorrectly-timed loop because the mocked memory does not natively mirror the clear-on-read bit behavior of the ARM SysTick timer. 

**Static Analysis Baseline:**
The baseline code utilizes a continuous while loop on the SysTick register, meaning it actively consumes 100% CPU cycles for the entire duration of the delay. By introducing a global `SysTick_Handler` interrupt and swapping out the polling loop for the `__WFI()` (Wait For Interrupt) instruction, the CPU is now actively put into a low-power sleep state, dropping CPU consumption down to near 0% while waiting for the delay to expire. This is a foundational architectural performance optimization for embedded ARM systems that dramatically cuts down on wasted CPU cycles and power consumption.

---
*PR created automatically by Jules for task [10080270090653153956](https://jules.google.com/task/10080270090653153956) started by @Rsmk27*