### PR TITLE
🔒 Fix hardcoded Wi-Fi credentials in example code

### DIFF
--- a/iot.html
+++ b/iot.html
@@ -169,11 +169,10 @@ client.connect(<span class="str">"dev.rightech.io"</span>, <span class="num">188
       </ol>
 
       <h3>STM32 → ESP8266 via UART (AT Commands)</h3>
-      <div class="code-block"><pre><span class="cm">/* Connect to Wi-Fi */</span>
-<span class="cm">/* WARNING: Do not hardcode credentials in production */</span>
-<span class="fn">HAL_UART_Transmit</span>(&amp;huart1,
-  (<span class="kw">uint8_t</span>*)<span class="str">"AT+CWJAP=\"YOUR_SSID\",\"YOUR_PASSWORD\"\r\n"</span>,
-  strlen(<span class="str">"AT+CWJAP=\"YOUR_SSID\",\"YOUR_PASSWORD\"\r\n"</span>), <span class="num">5000</span>);
+      <div class="code-block"><pre><span class="cm">/* Connect to Wi-Fi using predefined macros or variables */</span>
+<span class="kw">char</span> cmd[<span class="num">128</span>];
+<span class="fn">snprintf</span>(cmd, <span class="kw">sizeof</span>(cmd), <span class="str">"AT+CWJAP=\"%s\",\"%s\"\r\n"</span>, WIFI_SSID, WIFI_PASS);
+<span class="fn">HAL_UART_Transmit</span>(&amp;huart1, (<span class="kw">uint8_t</span>*)cmd, <span class="fn">strlen</span>(cmd), <span class="num">5000</span>);
 
 <span class="cm">/* Publish to MQTT topic via Rightech */</span>
 <span class="fn">HAL_UART_Transmit</span>(&amp;huart1,


### PR DESCRIPTION
🎯 **What:** Removed hardcoded Wi-Fi credentials (`YOUR_SSID` and `YOUR_PASSWORD`) from an example C code block in `iot.html`.
⚠️ **Risk:** Including hardcoded credentials in example code is an anti-pattern that encourages developers to directly replace placeholders with actual credentials in their code, creating a security risk.
🛡️ **Solution:** Replaced the hardcoded strings with a demonstration of how to dynamically construct the AT command string using `snprintf` and `WIFI_SSID` / `WIFI_PASS` variables, illustrating a more secure coding practice.

---
*PR created automatically by Jules for task [2098945957176569350](https://jules.google.com/task/2098945957176569350) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated STM32→ESP8266 UART connectivity example to use configurable credential variables for Wi-Fi authentication instead of hardcoded values, improving flexibility and security practices.
  * Improved code sample implementation with dynamic AT-command formatting for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->