### PR TITLE
🧪 Add test for EXTI15_10_IRQHandler

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,8 @@ test:
 	sed 's/while (1)/if (1) { loop_entered = 1; longjmp(test_env, 1); } while (0)/g' ../data/user_switch.c | sed 's/int main/int original_main/g' > user_switch_tested.c
 	$(CC) $(CFLAGS) -o test_error test_error_handler.c user_switch_tested.c
 	./test_error
+	$(CC) $(CFLAGS) -o test_exti15_10_irq test_exti15_10_irq.c user_switch_tested.c
+	./test_exti15_10_irq
 	sed 's/int main(void)/int original_main(void)/g' ../data/led_on_off_print_terminal.c | sed 's/void USART2_write(char ch)/void original_USART2_write(char ch)/g' > led_tested.c
 	$(CC) $(CFLAGS) -o test_usart2 test_usart2_print.c led_tested.c
 	./test_usart2
@@ -13,10 +15,10 @@ test:
 	./test_usart2_write
 
 clean:
-	rm -f test_error user_switch_tested.c test_usart2 led_tested.c test_usart2_write led_write_tested.c
+	rm -f test_error test_exti15_10_irq user_switch_tested.c test_usart2 led_tested.c test_usart2_write led_write_tested.c
 	sed 's/int main(void)/int original_main(void)/g' ../data/led_on_off_print_terminal.c | sed 's/while ((SysTick->CTRL & 0x10000) == 0)/while (mock_systick_check())/g' | sed '1i int mock_systick_check(void);' > led_delay_tested.c
 	$(CC) $(CFLAGS) -o test_delay test_delay.c led_delay_tested.c
 	./test_delay
 
 clean:
-	rm -f test_error user_switch_tested.c test_usart2 led_tested.c test_delay led_delay_tested.c
+	rm -f test_error test_exti15_10_irq user_switch_tested.c test_usart2 led_tested.c test_delay led_delay_tested.c

--- a/tests/test_exti15_10_irq.c
+++ b/tests/test_exti15_10_irq.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <assert.h>
+#include "main.h"
+
+int exti_irq_handler_called = 0;
+int exti_irq_handler_pin = 0;
+
+int disable_irq_called = 0;
+int loop_entered = 0;
+jmp_buf test_env;
+
+// Mocks
+void __disable_irq(void) {}
+void HAL_Init(void) {}
+int HAL_RCC_OscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct) { return HAL_OK; }
+int HAL_RCC_ClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, int FLatency) { return HAL_OK; }
+int HAL_USART_Init(USART_HandleTypeDef *husart) { return HAL_OK; }
+void HAL_GPIO_Init(int GPIOx, GPIO_InitTypeDef *GPIO_Init) {}
+void HAL_GPIO_WritePin(int GPIOx, int GPIO_Pin, int PinState) {}
+int HAL_GPIO_ReadPin(int GPIOx, int GPIO_Pin) { return 0; }
+void __WFI(void) {}
+void HAL_NVIC_SetPriority(int IRQn, int PreemptPriority, int SubPriority) {}
+void HAL_NVIC_EnableIRQ(int IRQn) {}
+
+void HAL_GPIO_EXTI_IRQHandler(int GPIO_Pin) {
+    exti_irq_handler_called = 1;
+    exti_irq_handler_pin = GPIO_Pin;
+}
+
+void EXTI15_10_IRQHandler(void);
+
+int main(void) {
+    printf("Starting EXTI15_10_IRQHandler test...\n");
+
+    EXTI15_10_IRQHandler();
+
+    assert(exti_irq_handler_called == 1);
+    assert(exti_irq_handler_pin == GPIO_PIN_13);
+
+    printf("EXTI15_10_IRQHandler test passed!\n");
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
A test was missing for `EXTI15_10_IRQHandler` in `data/user_switch.c`.

📊 **Coverage:** What scenarios are now tested
The new test verifies that `EXTI15_10_IRQHandler` calls `HAL_GPIO_EXTI_IRQHandler` passing `GPIO_PIN_13`.

✨ **Result:** The improvement in test coverage
`EXTI15_10_IRQHandler` is now covered by testing.

---
*PR created automatically by Jules for task [14562511233521515163](https://jules.google.com/task/14562511233521515163) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new test coverage for external interrupt handler validation
  * Implemented automated testing for interrupt functionality with mock hardware abstractions
  * Updated build system to compile and execute new interrupt tests as part of the standard test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->